### PR TITLE
Fix closing tag and add helper for video filenames

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,6 @@ window.wallpaperPropertyListener = {
 		</style>
 	</head>
 	<body style="overflow-x:hidden;overflow-y:hidden">
-	<video id="vid" src="1.webm" controls width="480" height="480">
-	</body>
+        <video id="vid" src="1.webm" controls width="480" height="480"></video>
+        </body>
 </html>

--- a/js/utils.js
+++ b/js/utils.js
@@ -486,11 +486,7 @@ function setVideo(index, x, y, w, h, fadeinTime, showTime, blur,file,fNum,vidNum
     video.id = "videoPV";
     video.volume = vidVol;
     video.height = h;
-	if (typeof vidNum === 'string' || vidNum instanceof String){
-		video.src=vidNum}
-	else{
-		video.src = vidNum+".webm";
-	}
+        video.src = getVideoPath(vidNum);
     video.autoplay = "autoplay";
     video.loop = "loop";
     video.style.position = "absolute";
@@ -534,7 +530,7 @@ function setLoopVideo(index, x, y, w, h, fadeinTime, showTime, blur,file,fNum,vi
     var video = document.createElement("video");
     var n = 26;//Number of Video
     video.id = "videoPV";
-    video.src = vidNum+".webm";
+    video.src = getVideoPath(vidNum);
     video.volume = vidVol;
     video.height = h;
     video.autoplay = "autoplay";
@@ -544,11 +540,11 @@ function setLoopVideo(index, x, y, w, h, fadeinTime, showTime, blur,file,fNum,vi
     function next() {
      vidNum++;
       if (vidNum<n) {
-        video.src = vidNum+".webm";
+        video.src = getVideoPath(vidNum);
       }
       else if(vidNum>=n){
-	vidNum=0;
-	video.src = vidNum+".webm";
+        vidNum=0;
+        video.src = getVideoPath(vidNum);
       }
 	video.play();
     }
@@ -601,7 +597,7 @@ function setShuffleVideo(index, x, y, w, h, fadeinTime, showTime, blur,file,fNum
     var VidList = [...Array(n).keys()];
     shuffle(VidList);
     video.id = "videoPV";
-    video.src = vidNum+".webm";
+    video.src = getVideoPath(vidNum);
     video.volume = vidVol;
     video.height = h;
     video.autoplay = "autoplay";
@@ -610,12 +606,12 @@ function setShuffleVideo(index, x, y, w, h, fadeinTime, showTime, blur,file,fNum
     video.addEventListener('ended', next, false);	
     function next() {
       if (vidNum<n) {
-        video.src = VidList[vidNum]+".webm";
+        video.src = getVideoPath(VidList[vidNum]);
       }
       else if(vidNum>=n){
 	shuffle(VidList);
-	vidNum=0;
-	video.src = VidList[vidNum]+".webm";
+        vidNum=0;
+        video.src = getVideoPath(VidList[vidNum]);
       }
 	video.play();
        vidNum++;
@@ -684,4 +680,11 @@ function getW() {
 
 function getH() {
     return screen.height * window.devicePixelRatio;
+}
+
+function getVideoPath(num) {
+    if (typeof num === 'string' || num instanceof String) {
+        return num;
+    }
+    return String(num).padStart(2, '0') + '.webm';
 }


### PR DESCRIPTION
## Summary
- close the video tag in `index.html`
- create `getVideoPath` in `js/utils.js`
- use the helper for all dynamic video sources

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f4adc218832781923ad879d6321a